### PR TITLE
Fix vertical positioning within status bar

### DIFF
--- a/lib/rdio-view.coffee
+++ b/lib/rdio-view.coffee
@@ -13,8 +13,8 @@ class RdioView extends View
   }
 
   @content: ->
-    @div class: 'rdio inline-block', =>
-      @div outlet: 'container', class: 'rdio-container', =>
+    @div class: 'rdio', =>
+      @div outlet: 'container', class: 'rdio-container inline-block', =>
         @span outlet: 'soundBars', class: 'rdio-sound-bars', =>
           @span class: 'rdio-sound-bar'
           @span class: 'rdio-sound-bar'

--- a/stylesheets/rdio.less
+++ b/stylesheets/rdio.less
@@ -2,15 +2,20 @@
 @import "ui-variables";
 
 // Rdio --------------------------------------------------
-.rdio a { color: @text-color-subtle }
+.rdio {
+  display: inline-block;
 
-.rdio-container[data-initiated] { display: inline-block }
+  a { color: @text-color-subtle }
+}
+
 .rdio-container {
   display: none;
   max-width: 300px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  &[data-initiated] { display: inline-block; }
 }
 
 // Sound bars --------------------------------------------


### PR DESCRIPTION
Some change in Atom seems to have noticeably messed up the vertical
positioning of the rdio-container element. This fix should straighten it out.

Before: ![Before](http://cl.ly/image/23371G1o2R1w)
After: ![After](http://cl.ly/image/1R0y401b3R1V)
